### PR TITLE
gh-6: remove Vercel GitHub secret fallback

### DIFF
--- a/.github/workflows/daily-refresh.yml
+++ b/.github/workflows/daily-refresh.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
   id-token: write
 
 jobs:
@@ -15,12 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     env:
-      AA_API_KEY: ${{ secrets.AA_API_KEY }}
-      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
       INFISICAL_DOMAIN: ${{ vars.INFISICAL_DOMAIN || 'https://app.infisical.com' }}
       INFISICAL_ENV_SLUG: ${{ vars.INFISICAL_ENV_SLUG || 'prod' }}
+      VERCEL_ORG_ID: team_48scplPIjV88LCscQpDUoNWo
+      VERCEL_PROJECT_ID: prj_nMlpkIMU9wkuDl8eK904g5C63p9b
     steps:
       - uses: actions/checkout@v4
 
@@ -44,20 +42,15 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: site/pnpm-lock.yaml
 
-      - name: Validate secret source
+      - name: Validate Infisical configuration
         env:
           INFISICAL_IDENTITY_ID: ${{ vars.INFISICAL_IDENTITY_ID }}
           INFISICAL_PROJECT_SLUG: ${{ vars.INFISICAL_PROJECT_SLUG }}
         run: |
-          if [ -n "${AA_API_KEY}" ]; then
-            echo "Using GitHub Actions secrets for runtime API keys."
-            exit 0
-          fi
-
           missing=0
           for name in INFISICAL_IDENTITY_ID INFISICAL_PROJECT_SLUG; do
             if [ -z "${!name}" ]; then
-              echo "::error::$name GitHub variable is required when AA_API_KEY is not provided as a repository secret."
+              echo "::error::$name GitHub variable is required for Infisical OIDC."
               missing=1
             fi
           done
@@ -66,7 +59,6 @@ jobs:
           fi
 
       - name: Fetch secrets from Infisical
-        if: ${{ env.AA_API_KEY == '' }}
         uses: Infisical/secrets-action@v1.0.15
         with:
           method: "oidc"
@@ -74,6 +66,19 @@ jobs:
           project-slug: ${{ vars.INFISICAL_PROJECT_SLUG }}
           env-slug: ${{ env.INFISICAL_ENV_SLUG }}
           domain: ${{ env.INFISICAL_DOMAIN }}
+
+      - name: Validate fetched secrets
+        run: |
+          missing=0
+          for name in AA_API_KEY VERCEL_TOKEN; do
+            if [ -z "${!name}" ]; then
+              echo "::error::$name is required from Infisical for this workflow."
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
 
       - name: Refresh
         run: |
@@ -101,14 +106,19 @@ jobs:
           name: model-intelligence-data
           path: data/latest
 
-      - name: Configure Pages
-        uses: actions/configure-pages@v5
+      - name: Pull Vercel project settings
+        run: pnpm dlx vercel@latest pull --yes --environment=production --token="${VERCEL_TOKEN}"
 
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: site/dist
+      - name: Build Vercel deployment
+        run: pnpm dlx vercel@latest build --prod --token="${VERCEL_TOKEN}"
 
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Deploy to Vercel
+        id: vercel_deploy
+        run: |
+          deployment_url="$(pnpm dlx vercel@latest deploy --prebuilt --prod --token="${VERCEL_TOKEN}" | tail -n 1)"
+          echo "deployment_url=${deployment_url}" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Vercel Deploy"
+            echo
+            echo "- Production URL: ${deployment_url}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -112,18 +112,19 @@ If Artificial Analysis temporarily rate limits the live refresh, the workflow re
 
 The daily workflow needs:
 
-- Runtime secrets provided through one of these paths:
-  - recommended now: GitHub repository secret `AA_API_KEY`
-  - optional: GitHub repository secret `OPENROUTER_API_KEY`
-  - optional later: Infisical OIDC with `INFISICAL_IDENTITY_ID` and `INFISICAL_PROJECT_SLUG` repository variables
+- Runtime secrets from Infisical via GitHub OIDC:
+  - required: `AA_API_KEY`
+  - required: `VERCEL_TOKEN`
+  - optional: `OPENROUTER_API_KEY`
+  - repository variables: `INFISICAL_IDENTITY_ID` and `INFISICAL_PROJECT_SLUG`
 
-See [docs/ops/secrets.md](/Users/rajeev/Code/openrouter-model-workbook-maintainer-v2/docs/ops/secrets.md) for the current runtime secret contract and migration path.
+See [docs/ops/secrets.md](/Users/rajeev/Code/openrouter-model-workbook-maintainer-v2/docs/ops/secrets.md) for the current runtime secret contract.
 
 ## Deployment
 
-The static guide is set up for GitHub Pages-style hosting via the `VITE_BASE_PATH` env var. The daily workflow deploys `site/dist` as a Pages artifact after a successful refresh.
+The static guide is hosted on Vercel. The daily workflow refreshes the data, rebuilds `site/dist`, and pushes a production deploy to Vercel after a successful refresh.
 
-For manual preview deployments, the repo now includes [vercel.json](/Users/rajeev/Code/openrouter-model-workbook-maintainer-v2/vercel.json), which tells Vercel to build and publish the static guide from `site/dist` instead of trying to treat the ETL repo root as a Python web app.
+For manual preview deployments, the repo includes [vercel.json](/Users/rajeev/Code/openrouter-model-workbook-maintainer-v2/vercel.json), which tells Vercel to build and publish the static guide from `site/dist` instead of trying to treat the ETL repo root as a Python web app.
 
 ## Docs
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -22,7 +22,8 @@ Optional:
 
 - `OPENROUTER_API_KEY`
 
-For local runs, prefer `infisical run --env=prod -- make refresh` once this repo has been linked to the right project. For GitHub Actions, the workflow currently prefers repository secrets for `AA_API_KEY` and `OPENROUTER_API_KEY`, and can optionally fetch them from Infisical OIDC when the repository variables described in [docs/ops/secrets.md](/Users/rajeev/Code/openrouter-model-workbook-maintainer-v2/docs/ops/secrets.md) are configured.
+For local runs, prefer `infisical run --env=prod -- make refresh` once this repo has been linked to the right project.
+For GitHub Actions, the workflow fetches runtime secrets from Infisical via OIDC. `AA_API_KEY` and `VERCEL_TOKEN` are required in Infisical `prod`, and `OPENROUTER_API_KEY` remains optional.
 
 ## Generated artifacts
 
@@ -47,8 +48,8 @@ For local runs, prefer `infisical run --env=prod -- make refresh` once this repo
 - rebuilds datasets and workbook
 - rebuilds the site
 - uploads workbook and dataset artifacts
-- deploys the static guide to GitHub Pages
-- uses repository secrets by default for runtime API keys, with optional Infisical OIDC support when the repo-specific identity wiring exists
+- deploys the static guide to Vercel
+- uses Infisical OIDC for runtime API keys and deploy credentials
 
 ## Manual preview deploy
 

--- a/docs/ops/secrets.md
+++ b/docs/ops/secrets.md
@@ -1,33 +1,23 @@
 # Secrets
 
-This repo currently supports two runtime secret paths:
-
-- GitHub repository secrets for CI and scheduled refreshes
-- Infisical for local runs and a future GitHub OIDC path once the repo-specific identity wiring is in place
+This repo uses Infisical as the runtime secret source for both local refreshes and the scheduled GitHub Actions refresh workflow.
 
 ## Runtime secrets
 
-Required for live refreshes:
+Required in Infisical `prod`:
 
 - `AA_API_KEY`
+- `VERCEL_TOKEN`
 
-Optional:
+Optional in Infisical `prod`:
 
 - `OPENROUTER_API_KEY`
-
-Store those values in the runtime system that is actually wired for the environment you are using:
-
-- GitHub Actions today:
-  - repository secret `AA_API_KEY`
-  - optional repository secret `OPENROUTER_API_KEY`
-- Local runs:
-  - prefer Infisical once this repo is linked to the correct project and environment
 
 Do not duplicate secret values into repository `.env.example` files beyond names-only documentation.
 
 ## Local usage
 
-Run the refresh pipeline through Infisical when you need live source access and the repo has been linked to the right project:
+Run the refresh pipeline through Infisical when you need live source access:
 
 ```bash
 infisical run --env=prod -- make refresh
@@ -37,20 +27,20 @@ If this repo uses a different Infisical project or environment than your machine
 
 ## GitHub Actions usage
 
-The scheduled refresh workflow first checks for GitHub repository secrets. If `AA_API_KEY` is present there, it uses the GitHub-provided value directly.
+The scheduled refresh workflow authenticates to Infisical with GitHub OIDC via `Infisical/secrets-action`.
 
-If repository secrets are not present, the workflow can authenticate to Infisical at runtime with OIDC via `Infisical/secrets-action`.
-
-Configure these GitHub repository variables if you want the OIDC path:
+Configure these GitHub repository variables:
 
 - `INFISICAL_IDENTITY_ID`
 - `INFISICAL_PROJECT_SLUG`
 
-Optional GitHub repository variables for the OIDC path:
+Optional GitHub repository variables:
 
 - `INFISICAL_ENV_SLUG`
   Defaults to `prod`.
 - `INFISICAL_DOMAIN`
   Defaults to `https://app.infisical.com`.
 
-The OIDC path then fetches `AA_API_KEY` and `OPENROUTER_API_KEY` directly from Infisical for the job lifetime.
+The workflow then fetches `AA_API_KEY`, optional `OPENROUTER_API_KEY`, and `VERCEL_TOKEN` directly from Infisical for the job lifetime.
+
+`VERCEL_ORG_ID` and `VERCEL_PROJECT_ID` are deployment identifiers, not secrets. They stay in workflow configuration rather than Infisical.

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "vite",
-  "installCommand": "npm --prefix site install",
-  "buildCommand": "VITE_BASE_PATH=/ npm --prefix site run build",
+  "installCommand": "pnpm --dir site install",
+  "buildCommand": "VITE_BASE_PATH=/ pnpm --dir site build",
   "outputDirectory": "site/dist"
 }


### PR DESCRIPTION
Why
Infisical now holds the real Vercel API token, so the workflow no longer needs a GitHub Actions secret fallback.

What
- require VERCEL_TOKEN from Infisical
- keep scheduled refreshes deploying to Vercel
- align deployment and secret docs with the live setup

Validation
- make validate
- make test
- daily refresh workflow run on gh-6 branch after deleting the GitHub VERCEL_TOKEN secret

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure & Deployment**
  * Migrated automated daily deployments to Vercel (replacing GitHub Pages deployment).
  * Centralized runtime secret management via Infisical OIDC authentication.
  * Updated build configuration to use pnpm instead of npm.

* **Documentation**
  * Updated operational guides with new deployment and secret management procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->